### PR TITLE
fix: set \n as a line separator

### DIFF
--- a/app/src/main/java/com/tommihirvonen/exifnotes/utilities/ExifToolCommandsBuilder.kt
+++ b/app/src/main/java/com/tommihirvonen/exifnotes/utilities/ExifToolCommandsBuilder.kt
@@ -70,7 +70,7 @@ class ExifToolCommandsBuilder(context: Context, private val roll: Roll, private 
 
         val quote = "\""
         val space = " "
-        val lineSep = "\r\n"
+        val lineSep = "\n"
         val camera = roll.camera
         for (frame in frameList) {
             //ExifTool path


### PR DESCRIPTION
`\r\n` is problematic on Unix systems. For example, on Linux I have to fix the file before I can run the commands.

From the info I found, `\n` should work properly on Windows as well.