### PR TITLE
Fix frame counts not being updated in MainScreen

### DIFF
--- a/app/src/main/java/com/tommihirvonen/exifnotes/di/EventBus.kt
+++ b/app/src/main/java/com/tommihirvonen/exifnotes/di/EventBus.kt
@@ -1,0 +1,18 @@
+package com.tommihirvonen.exifnotes.di
+
+import dagger.hilt.android.scopes.ActivityRetainedScoped
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import javax.inject.Inject
+
+@ActivityRetainedScoped
+class EventBus @Inject constructor() {
+
+    private val _frameCountRefreshEvents = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+
+    val frameCountRefreshEvents = _frameCountRefreshEvents.asSharedFlow()
+
+    suspend fun sendFrameCountRefreshEvent(rollId: Long) {
+        _frameCountRefreshEvents.emit(rollId)
+    }
+}

--- a/app/src/main/java/com/tommihirvonen/exifnotes/screens/frames/FramesScreen.kt
+++ b/app/src/main/java/com/tommihirvonen/exifnotes/screens/frames/FramesScreen.kt
@@ -175,7 +175,7 @@ fun FramesScreen(
         },
         onEditLabels = { showLabels = true },
         onDelete = {
-            selectedFrames.value.forEach(framesViewModel::deleteFrame)
+            framesViewModel.deleteFrames(selectedFrames.value)
         },
         onEdit = { showBatchEditDialog = true },
         onCopy = { showCopyDialog = true },


### PR DESCRIPTION
The frame counts in the rolls list do not update when frames are being added or deleted.

Use an event bus to transmit messages from FramesViewModel to MainViewModel to request frame count refresh for a given roll.